### PR TITLE
Align UBI9 base images with wiremock-consoledot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1749542372 AS build
+FROM registry.access.redhat.com/ubi9/ubi:1785388961 AS build
 USER 0
 ARG PROMETHEUS_VERSION=2.49.1
 ARG TARGET_ARCH="amd64"
@@ -10,7 +10,7 @@ RUN mkdir -p /opt/prometheus \
   && mv /opt/prometheus/prometheus-${PROMETHEUS_VERSION}.linux-${TARGET_ARCH}/* /opt/prometheus/
 
 # Runtime
-FROM registry.access.redhat.com/ubi9/openjdk-17
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.24-3
 COPY --from=build /opt/prometheus /opt/prometheus
 COPY config/prometheus.yml /opt/prometheus/prometheus.yml
 COPY utils/* /opt/prometheus/utils/
@@ -18,6 +18,8 @@ COPY start.sh /opt/prometheus/start.sh
 
 LABEL maintainer="Red Hat, Inc."
 LABEL version="ubi9"
+#label for EULA
+LABEL com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI"
 USER 0
 
 # Install python3


### PR DESCRIPTION
## Summary
- Bump build base from `ubi9/ubi:9.6-1749542372` to `ubi9/ubi:1785388961`
- Pin runtime to `ubi9/openjdk-17-runtime:1.24-3` (same as wiremock-consoledot)
- Add UBI EULA label for consistency with wiremock

## Test plan
- [ ] Konflux PR build succeeds with the new base images
- [ ] Image starts and Prometheus + importer endpoints respond as before
- [ ] Confirm `microdnf`/`pip` install steps still work on `openjdk-17-runtime`


Made with [Cursor](https://cursor.com)